### PR TITLE
Added \"$npm_execpath\" as executable to run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Using **Fast** is super simple. Simply `open the Fast folder` using your favorit
 **Note:** *We use [Yarn](https://yarnpkg.com/) for fast, reliable, and secure dependency management but feel free to use [NPM](https://www.npmjs.com/) if you prefer.*
 
 ### ⚠️ Are you on Windows?
-**Replace all instances of `$npm_execpath` in the package.json file with:**
+**Replace all instances of `$npm_execpath` in the [package.json](package.json) file with:**
 ```
 %npm_execpath%
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Using **Fast** is super simple. Simply `open the Fast folder` using your favorit
 
 **Note:** *We use [Yarn](https://yarnpkg.com/) for fast, reliable, and secure dependency management but feel free to use [NPM](https://www.npmjs.com/) if you prefer.*
 
+### ⚠️ Are you on Windows?
+**Replace all instances of `$npm_execpath` in the package.json file with:**
+```
+%npm_execpath%
+```
+
 ### Installing the necessary dependencies.
 ```
 yarn

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "start": "parcel -p 3000 index.html",
-    "serve": "yarn start --open",
+    "serve": "\"$npm_execpath\" start --open",
     "build": "parcel build index.html",
-    "deploy": "yarn build && cd dist && surge",
-    "redeploy": "yarn build && cd dist && surge --domain",
+    "deploy": "\"$npm_execpath\" build && cd dist && surge",
+    "redeploy": "\"$npm_execpath\" build && cd dist && surge --domain",
     "teardown": "surge teardown"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Develop, build, deploy, redeploy, and teardown frontend projects fast ⚡️",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**This PR fixes the bug of running NPM instead of yarn.** 

However, it introduces an issue for Windows users as they now will have to replace all instances of `$npm_execpath` in the `package.json` file with:

```
%npm_execpath%
```

We would like Fast to support any installer of your choice, however, this brings some complications to the definitions of our scripts. 

An alternative could be to use separate scripts for `yarn` and `npm`, but this feels like overkill and is not a scalable (future proof) solution.

Another option is to set a configuration file. This may be the best solution for the long run, but there is some additional setup needed to achieve that, and the support varies from one operating system to the other.

The approach presented in this PR seems the cleanest way to achieve this flexibility but it also has one drawback: On Linux/MacOS everything will work as expected but on Windows, users now will have to replace all instances of `$npm_execpath` in the `package.json` file with:

```
%npm_execpath%
```